### PR TITLE
add JS vis example

### DIFF
--- a/6_extend_catalog.ipynb
+++ b/6_extend_catalog.ipynb
@@ -40,8 +40,8 @@
    "source": [
     "import toml\n",
     "config = toml.load(\"config.toml\")\n",
-    "url = \"/\".join([\"https:/\", config[\"DOMAIN\"], config[\"FOLDER\"], \"dust\", \"dust_353GHz.fits\"])\n",
-    "url"
+    "url = f'https://{config[\"DOMAIN\"]}{config[\"FOLDER\"]}dust/dust_353GHz.fits'\n",
+    "print(url)"
    ]
   },
   {
@@ -72,11 +72,54 @@
     "It takes a few seconds to load the Python packages, but once they are loaded the map is displayed.\n",
     "We could add these links to the catalog, so that users could easily visualize the maps. The easiest way would be to modify the `create_markdown.py` script."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualization with JavaScript\n",
+    "\n",
+    "There are many JavaScript graphics libraries available, including [Chart.js](https://www.chartjs.org), [plotly](https://plotly.com), and [D3](https://d3js.org). Research groups with front end developers may want to incorporate JavaScript-based plots into their data portals.\n",
+    "\n",
+    "This example uses [Chart.js](https://www.chartjs.org) to create a simple line chart from a CSV file in one of your public datasets. The page takes the parameter `csv`, e.g.,\n",
+    "```\n",
+    "chart.html?csv=https://example.org/sample.csv\n",
+    "```\n",
+    "where `https://example.org/sample.csv` is URL encoded like the previous example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_url = f'https://{config[\"DOMAIN\"]}{config[\"FOLDER\"]}dust_synch_spectra/cls_dust.csv'\n",
+    "print(csv_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = {'csv': csv_url}\n",
+    "encoded_url = f\"https://{github_username}.github.io/cheapandfair-template/chart.html?\" + urlencode(params)\n",
+    "print(encoded_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "globus",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -90,9 +133,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
goes with [PR4](https://github.com/cheapandfair/cheapandfair-template/pull/4) on the template repo.

I used a formatted string to remove double slashes on the `//` url compared to a join.